### PR TITLE
Fix documentation not working on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,46 +147,9 @@ open ios/Runner.xcworkspace
 * Add the icon images of appropriate sizes to each app icon set.
 **Important:** The icons must be of the AppIcon type (app icon sets), not regular image sets.
 
-2.	**Modify Info.plist:**
-Open the file ios/Runner/Info.plist and add the alternate icons under the CFBundleIcons key:
-
-```xml
-<key>CFBundleIcons</key>
-<dict>
-    <key>CFBundlePrimaryIcon</key>
-    <dict>
-        <key>CFBundleIconFiles</key>
-        <array>
-            <string>AppIcon</string>
-        </array>
-    </dict>
-    <key>CFBundleAlternateIcons</key>
-    <dict>
-        <key>Icon1</key>
-        <dict>
-            <key>CFBundleIconFiles</key>
-            <array>
-                <string>AppIcon1</string>
-            </array>
-        </dict>
-        <key>Icon2</key>
-        <dict>
-            <key>CFBundleIconFiles</key>
-            <array>
-                <string>AppIcon2</string>
-            </array>
-        </dict>
-    </dict>
-</dict>
-```
-**Explanation:**
-* CFBundlePrimaryIcon defines the default app icon (AppIcon).
-* CFBundleAlternateIcons contains a dictionary of alternate icons.
-* Keys Icon1 and Icon2 are identifiers for your alternate icons used in the code.
-* CFBundleIconFiles contains an array of icon names corresponding to the sets in Assets.xcassets.
-
-3.	**Ensure Naming Consistency:**
-Make sure the names in Info.plist match exactly with the icon set names in Assets.xcassets.
+2.	**Edit XCode project:**
+Open your ios project i.e. Runner in Xcode, then go to Build Settings tab. 
+Go to `Assets Catalog Compiler Options`, and `Set Include All App Icon Assets` to `Yes`.
 
 4.	**Rebuild the Project:**
 After making the changes, run:


### PR DESCRIPTION
Thanks for your plugin, it's the only recent one I found that has a clean API and don't use extra background service.
At the end it works great, but I had trouble with the iOS config, your documentation didn't work for me.

What worked for me at the end :
Point 1 of the iOS confg is OK
But for the point 2, Instead of modify `Info.plist`, I just had to go to `Assets Catalog Compiler Options`, and `Set Include All App Icon Assets` to `Yes`. It's even easier !

This config was successfully published on the Apple Store.

To find this, I tried several combinaison of config from [flutter_dynamic_icon_plus](https://pub.dev/packages/flutter_dynamic_icon_plus) and [variable_app_icon](https://pub.dev/packages/variable_app_icon), which has different approach.

Shame I coulnd't create an issue directly, so here is a PR, but more for the idea, you should check it.